### PR TITLE
First stab at adding support for `placement === "after"`

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -105,10 +105,7 @@ export default function footnote_plugin (md) {
 
 		state.md.block.tokenize(state, startLine, endLine, true);
 
-		let first_token_index = state.tokens.findLastIndex((token) => token.type === "footnote_reference_open");
-		let current_footnote_tokens = state.tokens.slice(first_token_index);
-		let footnote_text = current_footnote_tokens.filter(token => token.content).reduce((acc, token) => acc + token.content, "");
-		state.env.footnotes.texts[label] = state.md.renderInline(footnote_text);
+		state.env.footnotes.texts[label] = state.md.renderInline(state.tokens.at(-2).content);
 
 		state.parentType = oldParentType;
 		state.blkIndent -= 4;

--- a/index.mjs
+++ b/index.mjs
@@ -55,6 +55,7 @@ export default function footnote_plugin (md) {
 
 		state.env.footnotes ??= {};
 		state.env.footnotes.refs ??= {};
+		state.env.footnotes.texts ??= {};
 
 		const label = state.src.slice(start + 2, pos - 2);
 		state.env.footnotes.refs[`:${label}`] = -1;
@@ -103,6 +104,11 @@ export default function footnote_plugin (md) {
 		}
 
 		state.md.block.tokenize(state, startLine, endLine, true);
+
+		let first_token_index = state.tokens.findLastIndex((token) => token.type === "footnote_reference_open");
+		let current_footnote_tokens = state.tokens.slice(first_token_index);
+		let footnote_text = current_footnote_tokens.filter(token => token.content).reduce((acc, token) => acc + token.content, "");
+		state.env.footnotes.texts[label] = state.md.renderInline(footnote_text);
 
 		state.parentType = oldParentType;
 		state.blkIndent -= 4;

--- a/index.mjs
+++ b/index.mjs
@@ -105,6 +105,8 @@ export default function footnote_plugin (md) {
 
 		state.md.block.tokenize(state, startLine, endLine, true);
 
+		// After tokenization, 3 tokens (of type paragraph_open, inline, and paragraph_close, respectively) were added to the stream of tokens.
+		// The token of type inline contains the actual footnote text
 		state.env.footnotes.texts[label] = state.md.renderInline(state.tokens.at(-2).content);
 
 		state.parentType = oldParentType;

--- a/src/partials.js
+++ b/src/partials.js
@@ -39,7 +39,16 @@ export function render_footnote_ref (tokens, idx, options, env, slf) {
 		a_attrs += ` epub:type="noteref"`;
 	}
 
-	return `<a ${ a_attrs }>${caption}</a>`;
+	let ret = `<a ${ a_attrs }>${caption}</a>`;
+
+	if (options.placement === "after") {
+		let label = tokens[idx].meta.label;
+		let footnote_text = `<span class="footnote-text inline" hidden>${ env.footnotes.texts[label] }</span>`;
+
+		ret += footnote_text;
+	}
+
+	return ret;
 }
 
 export function render_footnote_block_open (tokens, idx, options) {


### PR DESCRIPTION
Footnote text associated with it via its label is stored in the `env.footnotes.texts` object.